### PR TITLE
add babel-plugin-add-module-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "scripts": {
     "test": "gulp test"
   },
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ function createConfig() {
   return {
     plugins: [
       require.resolve('babel-plugin-transform-decorators-legacy'),
+      require.resolve('babel-plugin-add-module-exports'),
     ],
     presets: [
       require.resolve('babel-preset-react'),


### PR DESCRIPTION
This PR adds https://github.com/59naga/babel-plugin-add-module-exports which allows to `require('some-module')` exported using `export` and transpiled by Babel. Before you would have to `require('some-module').default`.
This will be usefull for testing ES6 React modules.